### PR TITLE
Use \section for "Exercice" titles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.aux
+*.fdb_latexmk
+*.fls
+*.log
+*.pdf

--- a/exam.cls
+++ b/exam.cls
@@ -59,6 +59,9 @@
 \RequirePackage{adjustbox}
 \RequirePackage{refcount}
 % \RequirePackage{tikz}
+\RequirePackage{titlesec}
+
+\titlespacing*{\section} {0pt}{0ex}{0ex}
 
 \linespread{1.05}
 
@@ -235,7 +238,7 @@
   \StrLen{#2}[\mystringlen]%
   \ifthenelse{\mystringlen > 0}{\def\@temp{-- #2}}{\def\@temp{}}%
   \vspace{0.3cm}
-  \noindent\textbf{\Large Exercice \arabic{QE} \@temp{} ($\approx$ #1 points)}%
+  \section*{Exercice \arabic{QE} \@temp{} ($\approx$ #1 points)}
   \setcounter{tempe}{\arabic{QE}}%
   \stepcounter{QE}%
   \vspace{0.3cm}


### PR DESCRIPTION
Currently the template relies on regular text to display "Exercice" titles. While this works well in most cases, this can lead to LaTeX deciding to display such title alone at the bottom of a page like this:

![Capture d’écran du 2024-03-28 13-32-33](https://github.com/correctexam/latextemplate/assets/5868014/94fa6dfa-dbb4-44c2-b950-b55ab2c0ca9b)


To address this, this PR makes use of `\section*` for "Exercice" titles, which LaTeX never wants to display at the bottom of a page. With the same document as above, the result is:

![Capture d’écran du 2024-03-28 13-31-58](https://github.com/correctexam/latextemplate/assets/5868014/2d08a17d-9069-45df-9f41-1a268194e5ce)

