### PR TITLE
Add questionExamBlock environment

### DIFF
--- a/exam-example.tex
+++ b/exam-example.tex
@@ -162,4 +162,13 @@ You can also write some text with inline boxes \inlineAnswerBox{} that students 
 \end{center}
 }
 
+
+% Questions can also be created with an environment.
+% This ensures the question will be displayed on the same page as the environment content.
+% For instance, this can be used to avoid starting a new page on an answer box.
+\begin{questionExamBlock}{\lipsum[5]}
+	\answerExam[white]{1.5}{18}{1}
+\end{questionExamBlock}
+
+
 \end{document}

--- a/exam.cls
+++ b/exam.cls
@@ -225,6 +225,13 @@
   \setcounter{subquestioncounter}{1} % reinit the local counter
 }
 
+\newenvironment{questionExamBlock}[2][]{%
+  \par\noindent\begin{minipage}{\linewidth}%
+  \StrLen{#1}[\argOneSize]%
+  \ifthenelse{\argOneSize > 0}{\questionExam{#2}[#1]}{\questionExam{#2}}%
+}
+{\end{minipage}}
+
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Exercice

--- a/exam.cls
+++ b/exam.cls
@@ -228,7 +228,7 @@
 \newenvironment{questionExamBlock}[2][]{%
   \par\noindent\begin{minipage}{\linewidth}%
   \StrLen{#1}[\argOneSize]%
-  \ifthenelse{\argOneSize > 0}{\questionExam{#2}[#1]}{\questionExam{#2}}%
+  \ifthenelse{\argOneSize > 0}{\questionExam[#1]{#2}}{\questionExam{#2}}%
 }
 {\end{minipage}}
 


### PR DESCRIPTION
A problem with the commands `\questionExam` and `\answerExam` is that they may lead to orphan answer boxes separated from questions, eg. like this:

```latex
\questionExam[q.mylabel]{\lipsum[1][3]}

% You can use the question's label like this:
\textbf{Reference to \cref{q.mylabel}}
% Warning: there is an issue when using question's label and section/sub-section.

\answerExam[white]{1.5}{8}{1}
```

![Capture d’écran du 2024-03-28 15-17-15](https://github.com/correctexam/latextemplate/assets/5868014/410cbb54-9fe0-4747-8026-0e550e790798)

This PR proposes a new environment called `questionExamBlock` which works the same as `questionExam`, but makes sure all content is in a minipage that ensures everything will always be shown together.


Example:
```latex
\begin{questionExamBlock}[q.mylabel]{\lipsum[1][3]}

   % You can use the question's label like this:
   \textbf{Reference to \cref{q.mylabel}}
   % Warning: there is an issue when using question's label and section/sub-section.

   \answerExam[white]{1.5}{8}{1}

\end{questionExamBlock}
```

Result:

![Capture d’écran du 2024-03-28 15-17-57](https://github.com/correctexam/latextemplate/assets/5868014/cd87ef47-2d5d-4caf-ad0d-15bcf1a59f9f)
