### PR TITLE
Add caution about minted and fboxsep in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,16 @@
 # latex template for correctexam
 
 The goal of this repo to to share update on correct exam latex template
+
+
+## Removed spacing in `\fbox` and consequences
+
+By design, this class sets the `fboxsep` length to `0`, which removes the inner spacing inside an `fbox`. 
+Not only does this affects the `\fbox` command, but this also affects all packages that rely on `fboxes` to draw frames.
+
+For example, the `minted` package provides a `frame` option which underneath relies on `fbox` to display lines or boxes around a code listing.
+Fortunately, `minted` provides a `framesep`  option which can be used to explicitly increase the spacing, and therefore "fix" (or compensate) the problem explained above:
+
+```latex
+\setminted{frame=lines,framesep=5pt}
+```

--- a/exam-example.tex
+++ b/exam-example.tex
@@ -22,7 +22,9 @@
 %\cfoot[\large\thepage~~/~~\pageref{LastPage}]{\large\thepage~~/~~\pageref{LastPage}}
 % but do not change the \lhead, \rhead, \lfoot, \rfoot, and \chead as they are used for page detection and IDs
 
-% CAUTION: this class sets the 'fboxsep' length to '0', which breaks spacing in the '\fbox' command. This affects packages that rely on '\fbox', such as the 'minted' package with the 'frame' option' − a fix for 'minted' is to set 'framesep=5pt' to replace the missing spacing.
+% CAUTION: this class sets the 'fboxsep' length to '0', which breaks spacing in the '\fbox' command. 
+% This affects packages that rely on '\fbox', such as the 'minted' package with the 'frame' option'
+% A fix for 'minted' is to set 'framesep=5pt' to replace the missing spacing.
 
 
 \title{\vspace*{-1cm}\huge Titre}

--- a/exam-example.tex
+++ b/exam-example.tex
@@ -22,6 +22,7 @@
 %\cfoot[\large\thepage~~/~~\pageref{LastPage}]{\large\thepage~~/~~\pageref{LastPage}}
 % but do not change the \lhead, \rhead, \lfoot, \rfoot, and \chead as they are used for page detection and IDs
 
+% CAUTION: this class sets the 'fboxsep' length to '0', which breaks spacing in the '\fbox' command. This affects packages that rely on '\fbox', such as the 'minted' package with the 'frame' option' − a fix for 'minted' is to set 'framesep=5pt' to replace the missing spacing.
 
 
 \title{\vspace*{-1cm}\huge Titre}


### PR DESCRIPTION
When using `minted` with this template, and when configuring `minted` to display a frame, there is a strange spacing issue happening:

![image](https://github.com/correctexam/latextemplate/assets/5868014/e85d301b-0c69-46e0-b46c-74de69675768)

I believe this is caused by this line in the code, which will remove spacing in an `fbox`, which is what `minted` uses underneath:

https://github.com/correctexam/latextemplate/blob/main/exam.cls#L296

This can be fixed using the `framesep` option in `minted` which allows to add extra inner space at the borders of a frame. For instance, with `framesep=5pt` we now get this result:

![image](https://github.com/correctexam/latextemplate/assets/5868014/3a927aa4-e3b2-49f4-a649-fd3a0da7d9e4)

---

Since I believe this cannot be easily fixed, this PR simply explains this problem in the README and how to fix it for `minted`.