### PR TITLE
Add possibility to set a number of boxes in `withid` option

### DIFF
--- a/exam-example.tex
+++ b/exam-example.tex
@@ -1,7 +1,7 @@
 % Options:
-% withid: adds a header line for writing the student's ID
-% We recommand to keep the twoside option as it permits to add a specific header (student' name) on each new page.
-\documentclass[a4paper,twoside,withid]{exam}
+% withid: adds a header line for writing the student's ID (if a value is given, will limit the amount of boxes)
+% We recommend to keep the twoside option as it permits to add a specific header (student' name) on each new page.
+\documentclass[a4paper,twoside,withid=8]{exam}
 
 % packages already loaded: graphicx, geometry, listings, lastpage, fancyhdr, xcolor, mathpazo, ifthen, xstring, qcm, enumitem, etoolbox, cleveref
 

--- a/exam.cls
+++ b/exam.cls
@@ -32,8 +32,9 @@
 \LoadClass{article}
 
 \newif\ifheaderWithID
+\newcommand{\nbBoxesStudentID}{}
 
-\DeclareOptionX{withid}{\headerWithIDtrue}
+\DeclareOptionX{withid}[19]{\headerWithIDtrue\renewcommand{\nbBoxesStudentID}{#1}}
 \ProcessOptionsX
 
 \RequirePackage{zref-savepos}
@@ -121,7 +122,7 @@
   \begin{tabular}{rl}
     \textbf{\small NOM :} & \zsavepos{lastnamebox}\multido{}{\nbBoxesHeaderLine}{~\boxStudentID}\\
     \textbf{\small PRÉNOM :} & \zsavepos{firstnamebox}\multido{}{\nbBoxesHeaderLine}{~\boxStudentID}\\
-    \ifheaderWithID \textbf{\small NUM ETD :} & \zsavepos{stdidbox}\multido{}{\nbBoxesHeaderLine}{~\boxStudentID} \else \\  \fi
+    \ifheaderWithID \textbf{\small NUM ETD :} & \zsavepos{stdidbox}\multido{}{\nbBoxesStudentID}{~\boxStudentID} \else \\  \fi
   \end{tabular}
 }%
 \ifheaderWithID%


### PR DESCRIPTION
Currently the template always generates exactly 19 boxes in the header for each input (first name, last name, ID), which looks like this:

![image](https://github.com/correctexam/latextemplate/assets/5868014/ac72a5df-8dba-4d9f-9568-00d68caa980f)

This PR adds the possibility to give a value so the `withid` option, in order to limit the amount of boxes for the ID. For instance, using `withid=8`, the result becomes:

![image](https://github.com/correctexam/latextemplate/assets/5868014/8455add1-b8d6-4431-b871-ca8f8634b74f)


