### PR TITLE
Fix crossref with questionExamBlock

### DIFF
--- a/exam-example.tex
+++ b/exam-example.tex
@@ -164,12 +164,19 @@ You can also write some text with inline boxes \inlineAnswerBox{} that students 
 }
 
 
-% Questions can also be created with an environment.
+% Questions can also be created with a questionExamBlock environment.
 % This ensures the question will be displayed on the same page as the environment content.
 % For instance, this can be used to avoid starting a new page on an answer box.
 \begin{questionExamBlock}{\lipsum[5]}
 	\answerExam[white]{1.5}{18}{1}
 \end{questionExamBlock}
+
+% Similar to regular questions, a label can be set on a questionExamBlock.
+\begin{questionExamBlock}[q.otherlabel]{\lipsum[6][1]}
+	\answerExam[white]{1.5}{10}{1}
+\end{questionExamBlock}
+
+\textbf{Reference to \cref{q.otherlabel}}
 
 
 \end{document}

--- a/exam.cls
+++ b/exam.cls
@@ -305,7 +305,6 @@
 \newcommand{\answerExam}[4][black]{%
 % Getting the count value of the current question
 \setcounter{tempq}{\arabic{Q}}%
-\addtocounter{tempq}{-1}%
 
 % setting the dot color
 \renewcommand{\answerExamDotColor}{#1}%
@@ -378,7 +377,6 @@
 \newcommand{\answerExamContent}[1]{%
 % Getting the count value of the current question
 \setcounter{tempq}{\arabic{Q}}%
-\addtocounter{tempq}{-1}%
 % Simulation for getting the height of the box
 \settototalheight{\heighOfBox}{\fbox{\parbox{\textwidth}{%
   \noindent\rule{0pt}{1.5\baselineskip}%
@@ -423,7 +421,6 @@
 \newcommand{\inlineAnswerBox}[1][10]{%
 % Getting the count value of the current question
 \setcounter{tempq}{\arabic{Q}}%
-\addtocounter{tempq}{-1}%
 %
 \fpSub{\spacestoinclude}{#1}{1}%
 %% Computing the dimensions of ID boxes

--- a/exam.cls
+++ b/exam.cls
@@ -201,7 +201,6 @@
 % Question
 
 \newcounter{Q}
-\refstepcounter{Q}
 
 % Temp counter used in answer box for questions
 \newcounter{tempq}
@@ -217,12 +216,13 @@
 \newcommand{\questionExam}[2][]{%
   % #1: optional label for the question
   % #2: the question text
+
+  % Writing the question text
+  \smallskip%
+  \noindent\refstepcounter{Q}\textbf{Q.\arabic{Q}}~#2%
   % Registering the label if provided
   \StrLen{#1}[\mystringlen]%
   \ifthenelse{\mystringlen > 0}{\label[question]{#1}}%
-  % Writing the question text
-  \smallskip%
-  \noindent\textbf{Q.\arabic{Q}}\refstepcounter{Q}~#2%
   \medskip%
   \setcounter{subquestioncounter}{1} % reinit the local counter
 }


### PR DESCRIPTION
A weird problem was appearing with the new `questionExamBlock` environment when it comes to crossrefs, with the question number always off when referencing it:

```latex
\begin{questionExamBlock}[q.otherlabel]{\lipsum[6][1]}
	\answerExam[white]{1.5}{10}{1}
\end{questionExamBlock}

\textbf{Reference to \cref{q.otherlabel}}
```

![image](https://github.com/correctexam/latextemplate/assets/5868014/19859ea1-59f4-4a3f-858d-bcd986aa7fa5)

This PR changes how the `Q` counter is managed in the following way:

- `Q` is initialized to `0` instead if `1`,
- `refstepcounter` is called before printing `Q`,
- `label` is called after `refstepcounter`,
- when `Q` is used for preparing metadata, don't decrement it anymore (since now it starts at `0`)

This fixes the original problem, and now we get the correct result:

![image](https://github.com/correctexam/latextemplate/assets/5868014/5e357693-3e1c-432b-a424-46498dfedc25)


**Note that for now I have not tried whether this creates issues when the PDF is imported in correctexam.**