### PR TITLE
fix student ID being mandatory

### DIFF
--- a/correctexam.cls
+++ b/correctexam.cls
@@ -10,7 +10,7 @@
 \newif\ifheaderWithID
 \newif\ifanonymousExam
 
-\newcommand{\nbBoxesStudentID}{}
+\newcommand{\nbBoxesStudentID}{0}
 
 \DeclareOptionX{anonymous}[4]{\anonymousExamtrue\renewcommand{\nbBoxesStudentID}{#1}}
 \DeclareOptionX{withid}[19]{\headerWithIDtrue\renewcommand{\nbBoxesStudentID}{#1}}


### PR DESCRIPTION
It feels like using the student ID should be an _option_ (as it was before #1).  
Currently, when using `exam-example-en.tex`, if we simply write
```
\documentclass[a4paper,twoside]{correctexam}
```
instead of
```
\documentclass[a4paper,twoside,withid=8]{correctexam}
```
or
```
\documentclass[a4paper,twoside,anonymous]{correctexam}
```
the document fails to compile.

Using rubber to focus on the errors thrown:
```
There were errors compiling exam-example-en.tex: Recipe for exam-example-en.pdf failed.
./exam-example-en.tex:92: Missing number, treated as zero.
./exam-example-en.tex:131: Missing number, treated as zero.
./exam-example-en.tex:152: Missing number, treated as zero.
./exam-example-en.tex:181: Missing number, treated as zero.
./exam-example-en.tex:181: leading text: \textbf{Reference to \cref{q.otherlabel}}
```


The fix is here to just set 0 as the default number of boxes when the _option_ `withid` is not specified (separate from the default of 19 used when the option is used without a value).