### PR TITLE
Enable proper internationalisation

### DIFF
--- a/correctexam.cls
+++ b/correctexam.cls
@@ -40,10 +40,27 @@
 % \RequirePackage{tikz}
 \RequirePackage{titlesec}
 \RequirePackage{minibox}
+\RequirePackage{babel}
 
 \titlespacing*{\section} {0pt}{0ex}{0ex}
 
 \linespread{1.05}
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% I12N
+\newcommand{\exercisename}{Exercise}
+\newcommand{\studentlastname}{LAST NAME:}
+\newcommand{\studentfirstname}{FIRST NAME:}
+\newcommand{\studentidname}{STUDENT ID:}
+\newcommand{\studentanonname}{ANONYMOUS ID:}
+
+\addto\captionsfrench{
+  \renewcommand{\exercisename}{Exercice}
+  \renewcommand{\studentlastname}{NOM~:}
+  \renewcommand{\studentfirstname}{PRÉNOM~:}
+  \renewcommand{\studentidname}{\No ÉTUDIANT~:}
+  \renewcommand{\studentanonname}{\No ANONYMAT~:}
+}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Document geometry
@@ -107,11 +124,11 @@
   \setlength{\tabcolsep}{0.2em}%
   \begin{tabular}{rl}
     \ifanonymousExam%
-      \textbf{\small \No ANONYMAT~:} & \zsavepos{stdidbox}\multido{}{\nbBoxesStudentID}{~\boxID}\\
+      \textbf{\small\studentanonname} & \zsavepos{stdidbox}\multido{}{\nbBoxesStudentID}{~\boxID}\\
     \else
-      \textbf{\small NOM :} & \zsavepos{lastnamebox}\multido{}{\nbBoxesHeaderLine}{~\boxID}\\
-      \textbf{\small PRÉNOM :} & \zsavepos{firstnamebox}\multido{}{\nbBoxesHeaderLine}{~\boxID}\\
-      \ifheaderWithID \textbf{\small NUM ETD :} & \zsavepos{stdidbox}\multido{}{\nbBoxesStudentID}{~\boxID} \else \\  \fi
+      \textbf{\small\studentlastname{}} & \zsavepos{lastnamebox}\multido{}{\nbBoxesHeaderLine}{~\boxID}\\
+      \textbf{\small\studentfirstname{}} & \zsavepos{firstnamebox}\multido{}{\nbBoxesHeaderLine}{~\boxID}\\
+      \ifheaderWithID \textbf{\small\studentidname{}} & \zsavepos{stdidbox}\multido{}{\nbBoxesStudentID}{~\boxID} \else \\  \fi
     \fi
   \end{tabular}
 }%
@@ -235,7 +252,7 @@
   \StrLen{#2}[\mystringlen]%
   \ifthenelse{\mystringlen > 0}{\def\@temp{-- #2}}{\def\@temp{}}%
   \vspace{0.3cm}
-  \section*{Exercice \arabic{QE} \@temp{} ($\approx$ #1 points)}
+  \section*{\exercisename{} \arabic{QE} \@temp{} ($\approx$ #1 points)}
   \setcounter{tempe}{\arabic{QE}}%
   \stepcounter{QE}%
   \vspace{0.3cm}

--- a/exam-example-en.tex
+++ b/exam-example-en.tex
@@ -1,3 +1,4 @@
+\PassOptionsToPackage{english}{babel}
 % Options:
 % withid: adds a header line for writing the student's ID (if a value is given, will limit the number of boxes)
 % anonymous: replaces student name fieds by an anonimity number (if a value is given, it specifies the number of boxes)
@@ -10,7 +11,6 @@
 
 \usepackage[T1]{fontenc}
 \usepackage[final,activate={true,nocompatibility},kerning=true,spacing=true]{microtype}
-\usepackage[english,french]{babel}
 \usepackage[scaled=0.9]{DejaVuSansMono}
 \usepackage{lipsum} % For demo. To remove
 \usepackage{tikz}

--- a/exemple-examen-fr.tex
+++ b/exemple-examen-fr.tex
@@ -1,3 +1,4 @@
+\PassOptionsToPackage{french}{babel}
 % Options :
 % withid : ajoute une ligne d'en-tête pour écrire l'identifiant de l'étudiant (si une valeur est donnée, cela limitera le nombre de cases)
 % anonymous : remplace les champs de nom et id par un numéro d'anonymat (si une valeur est donnée, cela limitera le nombre de cases)
@@ -9,7 +10,6 @@
 
 \usepackage[T1]{fontenc}
 \usepackage[final,activate={true,nocompatibility},kerning=true,spacing=true]{microtype}
-\usepackage[english,french]{babel}
 \usepackage[scaled=0.9]{DejaVuSansMono}
 \usepackage{lipsum} % Seulement pour l'example, vous pouvez supprimer cette ligne
 \usepackage{tikz}


### PR DESCRIPTION
The template is currently provided in both French and English.
However, French terms such as "Exercice," "Nom," "Prénom," and "Num etd" are hardcoded in the main .cls file, which affects both language options.

This pull request switches these terms to English defaults and introduces basic internationalization.
It does so by allowing users to specify language options using `\PassOptionsToPackage{french}{babel}` at the start of the TeX document.

One limitation of this change is that it breaks older documents using the babel package (so... all of them?), as it cannot be loaded twice.
The fix is straightforward: replace any `\usepackage[foo]{babel}` instances with the corresponding `\PassOptionsToPackage{foo}{babel}`.